### PR TITLE
Allow dynamic tagging on logs

### DIFF
--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -35,7 +35,7 @@ describe('DatadogTransport#log(info, callback)', () => {
     ).query({
       service: 'service',
       ddsource: 'ddsource',
-      ddtags: 'ddtags',
+      ddtags: 'env:production,trace_id:123,span_id:456',
       hostname: 'hostname'
     }).reply(204)
   })
@@ -49,11 +49,14 @@ describe('DatadogTransport#log(info, callback)', () => {
       apiKey: 'apikey',
       service: 'service',
       ddsource: 'ddsource',
-      ddtags: 'ddtags',
+      ddtags: 'env:production',
       hostname: 'hostname'
     })
     const callback = jest.fn()
-    await transport.log({ foo: 'bar' }, callback)
+    await transport.log({
+      foo: 'bar',
+      ddtags: 'trace_id:123,span_id:456'
+    }, callback)
     expect(scope.isDone()).toBe(true)
     expect(callback).toHaveBeenCalled()
   })

--- a/lib/index.js
+++ b/lib/index.js
@@ -19,25 +19,9 @@ module.exports = class DatadogTransport extends Transport {
     if (!opts.apiKey) {
       throw new Error('Missing required option: `apiKey`')
     }
-
+    this.opts = opts
     // https://docs.datadoghq.com/api/?lang=python#send-logs-over-http
-    const api = `https://http-intake.logs.datadoghq.com/v1/input/${opts.apiKey}`
-
-    const query = [
-      'service',
-      'ddsource',
-      'ddtags',
-      'hostname'
-    ].reduce((a, b) => {
-      if (opts.hasOwnProperty(b)) {
-        a[b] = opts[b]
-      }
-      return a
-    }, {})
-
-    const queryString = querystring.encode(query)
-
-    this.api = queryString ? `${api}?${queryString}` : api
+    this.api = `https://http-intake.logs.datadoghq.com/v1/input/${opts.apiKey}`
   }
 
   async log (info, callback) {
@@ -45,13 +29,37 @@ module.exports = class DatadogTransport extends Transport {
       this.emit('logged', info)
     })
 
+    const query = [
+      'service',
+      'ddsource',
+      'ddtags',
+      'hostname'
+    ].reduce((a, b) => {
+      if (this.opts.hasOwnProperty(b)) {
+        a[b] = this.opts[b]
+      }
+      return a
+    }, {})
+
+    const { ddtags, ...logs } = info
+    if (ddtags) {
+      if (query.ddtags) {
+        query.ddtags += `,${ddtags}`
+      } else {
+        query.ddtags = ddtags
+      }
+    }
+
+    const queryString = querystring.encode(query)
+    const api = querystring ? `${this.api}?${queryString}` : this.api
+
     // Perform the writing to the remote service
-    await fetch(this.api, {
+    await fetch(api, {
       method: 'POST',
       headers: {
         'content-type': 'application/json'
       },
-      body: JSON.stringify(info)
+      body: JSON.stringify(logs)
     })
     callback()
   }


### PR DESCRIPTION
If the log body has a 'ddtags' key, it's value would be forwarded along with any static tags set on the logger