### PR TITLE
Add trace injection out of the box

### DIFF
--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -35,7 +35,7 @@ describe('DatadogTransport#log(info, callback)', () => {
     ).query({
       service: 'service',
       ddsource: 'ddsource',
-      ddtags: 'env:production,trace_id:123,span_id:456',
+      ddtags: 'env:production,trace_id:abc,span_id:def,tag_a:value_a,tag_b:value_b',
       hostname: 'hostname'
     }).reply(204)
   })
@@ -54,8 +54,12 @@ describe('DatadogTransport#log(info, callback)', () => {
     })
     const callback = jest.fn()
     await transport.log({
+      dd: {
+        trace_id: 'abc',
+        span_id: 'def'
+      },
       foo: 'bar',
-      ddtags: 'trace_id:123,span_id:456'
+      ddtags: 'tag_a:value_a,tag_b:value_b'
     }, callback)
     expect(scope.isDone()).toBe(true)
     expect(callback).toHaveBeenCalled()

--- a/lib/index.js
+++ b/lib/index.js
@@ -41,14 +41,18 @@ module.exports = class DatadogTransport extends Transport {
       return a
     }, {})
 
-    const { ddtags, ...logs } = info
-    if (ddtags) {
+    const { dd, ddtags, ...logs } = info
+
+    const append = (string) => {
       if (query.ddtags) {
-        query.ddtags += `,${ddtags}`
+        query.ddtags += `,${string}`
       } else {
         query.ddtags = ddtags
       }
     }
+
+    dd && append(`trace_id:${dd.trace_id},span_id:${dd.span_id}`)
+    ddtags && append(ddtags)
 
     const queryString = querystring.encode(query)
     const api = querystring ? `${this.api}?${queryString}` : this.api


### PR DESCRIPTION
Datadog's dd-trace package injects traces in logs under the key 'dd'

If present, set them as tags