### PR TITLE
Give the transport a name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 /index.js
+coverage

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -17,6 +17,13 @@ it('throws an error if api key isn\'t passed in', () => {
   }
 })
 
+it('has a name', () => {
+  const transport = new DatadogTransport({
+    apiKey: 'apiKey'
+  })
+  expect(transport.name).toEqual('datadog')
+})
+
 describe('DatadogTransport#log(info, callback)', () => {
   [
     {

--- a/lib/index.js
+++ b/lib/index.js
@@ -28,6 +28,10 @@ module.exports = class DatadogTransport extends Transport {
     }
   }
 
+  get name () {
+    return 'datadog'
+  }
+
   async log (info, callback) {
     setImmediate(() => {
       this.emit('logged', info)

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,25 +2,25 @@ const Transport = require('winston-transport')
 const querystring = require('querystring')
 const fetch = require('node-fetch')
 
-//
-// Inherit from `winston-transport` so you can take advantage
-// of the base functionality and `.exceptions.handle()`.
-//
+/**
+ * Class for sending logging information to Datadog's HTTPS intakes
+ * @extends Transport
+ */
 module.exports = class DatadogTransport extends Transport {
+  /**
+   * Constructor for the Datadog Transport responsible for making
+   * HTTP requests whenever log messages are received
+   * @param {!Object} opts Transport options
+   * @param {string} opts.apiKey The Datadog API key
+   * @param {string} [intakeRegion] The intake region to be used
+   */
   constructor (opts = {}) {
     super(opts)
 
-    //
-    // Consume any custom options here. e.g.:
-    // - Connection information for databases
-    // - Authentication information for APIs (e.g. loggly, papertrail,
-    //   logentries, etc.).
-    //
     if (!opts.apiKey) {
       throw new Error('Missing required option: `apiKey`')
     }
     this.opts = opts
-    // https://docs.datadoghq.com/api/?lang=python#send-logs-over-http
     if (this.opts.intakeRegion === 'eu') {
       this.api = `https://http-intake.logs.datadoghq.eu/v1/input/${opts.apiKey}`
     } else {
@@ -28,10 +28,18 @@ module.exports = class DatadogTransport extends Transport {
     }
   }
 
+  /**
+   * Expose the name of the Transport
+   */
   get name () {
     return 'datadog'
   }
 
+  /**
+   * Core logging method exposed to Winston
+   * @param {!Object} info Information to be logged
+   * @param {function} callback Continuation to respond when complete
+   */
   async log (info, callback) {
     setImmediate(() => {
       this.emit('logged', info)


### PR DESCRIPTION
Added a read-only name to the transport, matching the pattern of the official transports. This can be useful to determine which transports have been added to the logger.