### PR TITLE
Catch and junk any exceptions from Fetch to avoid clients having to w…

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -82,6 +82,7 @@ module.exports = class DatadogTransport extends Transport {
         },
         body: JSON.stringify(logs)
       })
+    } catch (err) {
     } finally {
       callback()
     }


### PR DESCRIPTION
…rap logging in try...catch

In the event that `node-fetch` throws while shipping logs to the intake the exception isn't handled within the library. If the client hasn't wrapped the logging within its own try/catch block this leads to an unhandled promise error which can have serious consequences.

Longer term I'd like to add a retry mechanism for requests that fail, for example due to a transient network issue, but this PR simply guards clients from unexpected errors while logging.