### PR TITLE
Support additional US3 and US5 Zones

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -22,14 +22,14 @@ module.exports = class DatadogTransport extends Transport {
     }
     this.opts = opts
     if (this.opts.intakeRegion === 'eu') {
-			this.api = `https://http-intake.logs.datadoghq.eu/v1/input/${opts.apiKey}`
-		} else if (this.opts.intakeRegion === 'us3') {
-			this.api = `https://http-intake.logs.us3.datadoghq.com/v1/input/${opts.apiKey}`
-		} else if (this.opts.intakeRegion === 'us5') {
-			this.api = `https://http-intake.logs.us5.datadoghq.com/v1/input/${opts.apiKey}`
-		} else {
-			this.api = `https://http-intake.logs.datadoghq.com/v1/input/${opts.apiKey}`
-		}
+      this.api = `https://http-intake.logs.datadoghq.eu/v1/input/${opts.apiKey}`
+    } else if (this.opts.intakeRegion === 'us3') {
+      this.api = `https://http-intake.logs.us3.datadoghq.com/v1/input/${opts.apiKey}`
+    } else if (this.opts.intakeRegion === 'us5') {
+      this.api = `https://http-intake.logs.us5.datadoghq.com/v1/input/${opts.apiKey}`
+    } else {
+      this.api = `https://http-intake.logs.datadoghq.com/v1/input/${opts.apiKey}`
+    }
   }
 
   /**


### PR DESCRIPTION
Datadog has additional zones which use different API URI. This change adds support for those. 

See for example:
https://docs.datadoghq.com/logs/log_collection/?tabs=host
![Screen Shot 2022-06-30 at 1 19 05 PM](https://user-images.githubusercontent.com/7328115/176738805-2975b153-9e53-4f81-87d5-366cb4138a7a.png)

